### PR TITLE
gbif#88 Add compatibility for requests-cache 0.8

### DIFF
--- a/pygbif/caching.py
+++ b/pygbif/caching.py
@@ -1,8 +1,11 @@
 import requests_cache
-from requests_cache.core import remove_expired_responses
 import os.path
 import tempfile
 
+try:
+    from requests_cache import remove_expired_responses
+except ModuleNotFoundError:
+    from requests_cache.core import remove_expired_responses
 
 def caching(
     cache=False,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Unobtrusive backwards-compatible fix for recent incompatibility with `requests-cache`. 

## Description
<!--- Describe your changes in detail -->

When installing `pygbif` in a new environment, the package will break due to API changes in `requests-cache 8.x`. This pull request attempts to import `requests_cache.remove_expired_responses` before using the previous logic as a fallback. As a result, this change should have no effect on previous environment configurations.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

Fixes #88

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

N/A

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
