### PR TITLE
add progress bar to download_get

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ vcrpy==4.2.1
 pytest
 pytest-cov
 codecov
+tqdm>=4.66.1


### PR DESCRIPTION
I added a simple `tqdm` progress bar to the `gbif_GET_write` function.

## Description
I often need to download large files from GBIF and have wished I could see the progress. This fixes that. I don't know what the sentiment is toward requirements on this project, so I hope the inclusion of `tqdm` isn't against principle.

## Example
```python
import pygbif.occurences as occ

occ.download_get("0000066-140928181241064")
```
```bash
INFO:Download file size: 143097 bytes
100%|██████████| 143k/143k [00:00<00:00, 1.14MB/s]
INFO:On disk at [./0000066-140928181241064.zip](https://file+.vscode-resource.vscode-cdn.net/Users/dluks/local_projects/pygbif/0000066-140928181241064.zip)
{'path': './0000066-140928181241064.zip',
 'size': 143097,
 'key': '0000066-140928181241064'}
```

All tests continue to pass, but, given the minimal testing of `download_get` at present, I didn't add anything. I'm not exactly sure how I'd test this anyway 🤔 .
