### PR TITLE
Remove self.img from plot method

### DIFF
--- a/pygbif/maps/map.py
+++ b/pygbif/maps/map.py
@@ -215,7 +215,7 @@ class GbifMap(object):
         return path
 
     def plot(self):
-        plt.show(self.img)
+        plt.show()
 
 
 def __handle_year(year):


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
matplotlib's `show()` method doesn't accept image data as argument, instead it plots whatever is already opened in `__prep_plot()`. This change removes the argument, so the map is displayed after executing this method.

Without it it fails:
```
File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 421, in show
    return _get_backend_mod().show(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _Backend.show() takes 1 positional argument but 2 were given
```


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #86
## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
