### PR TITLE
Fix misspelled kingdomKey in download.py

### DIFF
--- a/pygbif/occurrences/download.py
+++ b/pygbif/occurrences/download.py
@@ -143,7 +143,7 @@ def download(
      - geoDistance = ``GEO_DISTANCE``
      - identifiedBy = ``IDENTIFIED_BY``
      - identifiedByID = ``IDENTIFIED_BY_ID``
-     - kingdomKey = ``KINGDON_KEY``
+     - kingdomKey = ``KINGDOM_KEY``
      - license = ``LICENSE``
      - locality = ``LOCALITY``
      - modified = ``MODIFIED``
@@ -699,7 +699,7 @@ key_lkup = {
     "geoDistance": "GEO_DISTANCE",
     "identifiedBy": "IDENTIFIED_BY",
     "identifiedByID": "IDENTIFIED_BY_ID",
-    "kingdomKey": "KINGDON_KEY",
+    "kingdomKey": "KINGDOM_KEY",
     "license": "LICENSE",
     "locality": "LOCALITY",
     "modified": "MODIFIED",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix misspelled API key.

## Description
<!--- Describe your changes in detail -->
`KINGDON_KEY` --> `KINGDOM_KEY`

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Fixes #153 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
res = pygbif.occurrences.download(
        [
            'kingdomKey = 1',
            'decimalLatitude > 65'
        ]
    )

print(res)
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
