### PR TITLE
Mwd fix plain exception use

### DIFF
--- a/pygbif/occurrences/__init__.py
+++ b/pygbif/occurrences/__init__.py
@@ -39,5 +39,6 @@ from .download import (
     download_cancel,
     download_describe,
     download_sql,
-    download_citation
+    download_citation,
+    GbifDownloadError,
 )

--- a/pygbif/occurrences/download.py
+++ b/pygbif/occurrences/download.py
@@ -41,7 +41,7 @@ def _parse_args(x):
     if re.search(r"\s+in", x):
         value_list = re.search(r"\[.*\]", x)
         if not value_list:
-            raise Exception(
+            raise ValueError(
                 "error: in predicate has to be associated with a list in square brackets (for example [1, 2, 3])"
             )
         else:
@@ -274,6 +274,10 @@ def download(
     return out, req.payload
 
 
+class GbifDownloadError(Exception):
+    pass
+
+
 class GbifDownload(object):
     def __init__(self, creator, email, polygon=None):
         """class to setup a JSON doc with the query and POST a request
@@ -337,7 +341,7 @@ class GbifDownload(object):
             self._main_pred_type = value
             self.payload["predicate"]["type"] = self._main_pred_type
         else:
-            raise Exception("main predicate combiner not a valid operator")
+            raise ValueError("main predicate combiner not a valid operator")
 
     @property
     def predicate(self):
@@ -354,7 +358,7 @@ class GbifDownload(object):
             self._predicate = value
             self.payload["predicate"] = self._predicate
         else:
-            raise Exception("predicate must be a dictionary")
+            raise ValueError("predicate must be a dictionary")
 
     @property
     def format(self):
@@ -371,7 +375,7 @@ class GbifDownload(object):
             self._format = value
             self.payload["format"] = self._format
         else:
-            raise Exception(
+            raise ValueError(
                 "format must be one of the accepted download formats of GBIF "
                 + ", ".join(formats)
             )
@@ -396,7 +400,7 @@ class GbifDownload(object):
         if predicate_type:
             self.predicates.append({"type": predicate_type, "key": key, "value": value})
         else:
-            raise Exception("predicate type not a valid operator")
+            raise ValueError("predicate type not a valid operator")
 
     def add_predicate_dict(self, predicate_dictionary):
         """
@@ -409,7 +413,7 @@ class GbifDownload(object):
         if isinstance(predicate_dictionary, dict):
             self.predicates.append(predicate_dictionary)
         else:
-            raise Exception("argument must be a dictionary")
+            raise TypeError("argument must be a dictionary")
 
     @staticmethod
     def _extract_values(values_list):
@@ -427,7 +431,7 @@ class GbifDownload(object):
         elif isinstance(values_list, list):
             values = values_list
         else:
-            raise Exception("input datatype not supported.")
+            raise TypeError("input datatype not supported.")
         return values
 
     def add_iterative_predicate(self, key, values_list):
@@ -481,7 +485,7 @@ class GbifDownload(object):
             headers=self.header,
         )
         if r.status_code > 203:
-            raise Exception(
+            raise GbifDownloadError(
                 "error: "
                 + r.text
                 + ", with error status code "
@@ -616,7 +620,7 @@ def download_get(key, path=".", **kwargs):
     """
     meta = occurrences.download_meta(key)
     if meta["status"] != "SUCCEEDED":
-        raise Exception('download "%s" not of status SUCCEEDED' % key)
+        raise GbifDownloadError('download "%s" not of status SUCCEEDED' % key)
     else:
         logging.info("Download file size: %s bytes" % meta["size"])
         url = "http://api.gbif.org/v1/occurrence/download/request/" + key
@@ -712,7 +716,7 @@ def download_sql(sql,
         headers=header,
     )
     if r.status_code > 203:
-        raise Exception(
+        raise GbifDownloadError(
             "error: "
             + r.text
             + ", with error status code "


### PR DESCRIPTION
This PR removes instances where the base Exception class is raised, which is problematic in Python.

This is my first PR on this project - I apologise if I've missed any process guidance - please do correct me and I'll do what I can to get it right! One think you ask is people run black, which I have done, but it generated a bunch of changes on top of the dev branch before I changed anything, so I've made those a stand alone commit just incase black out of the box isn't doing the right thing in my environment.

## Description

Python generally uses a hierarchy of exception types derived from the base
exception class. Raising the base class itself is discouraged, as it
forces the user to be overly broad in their exception handlers which might
lead to other kinds of errors being overlooked. This is flagged in tools
like pylint for both the raiser (W0719)[0] and the handler (W0718). The
Python style guide in PEP8 gives some guidance on building up exception
hierarchies for modules.

This PR does two things:

1. Where possible replaces instances where Exception is raised with
the more specific inbuild exception type (ValueError or TypeError).

2. Where not possible, it creates a new exception class that can be caught
for download specific errors.

This means that code using the pygbif download functionality can
handle specific errors without being overly broad and being flagged
by tools like pylint.

[0] https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/broad-exception-raised.html
[1] https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/broad-exception-caught.html
[2] https://peps.python.org/pep-0008/


## Related Issue

I've not raised an issue for this, but I can do if that's required! 

## Example

I made this PR after I hit an issue whilst migrating from an older version to 0.6.6. pygbif threw the following error:

```
Traceback (most recent call last):
  File "/Users/michael/venvs/star/bin/aoh-fetch-gbif-data", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/michael/dev/aoh-calculator/aoh/validation/fetch_gbif_data.py", line 307, in main
    fetch_gbif_data(
    ~~~~~~~~~~~~~~~^
        args.collated_data_path,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        args.output_dir_path,
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/michael/dev/aoh-calculator/aoh/validation/fetch_gbif_data.py", line 210, in fetch_gbif_data
    download_key = request.post_download(gbif_username, gbif_password)
  File "/Users/michael/venvs/star/lib/python3.13/site-packages/pygbif/occurrences/download.py", line 484, in post_download
    raise Exception(
    ...<5 lines>...
    )
Exception: error: [
  "HTTP 503 Backend fetch failed",
  "Request XID: 23823044"
]
, with error status code 503check your number of active downloads.
```

To correctly handle that exception and provide feedback to the users of the tool I'm writing I'd have to wrap it in an exception handler that catches either all exceptions or `Exception` which would be effectively the same. This is bad practice and unsafe (to me), and pylint would also require I make an exception for this.
