### PR TITLE
docs: clarify GBIF_USER/GBIF_PWD requirements for download endpoints

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,17 @@ Example usage:
     occ.download_describe("simpleCsv")
     occ.download_sql("SELECT gbifid,countryCode FROM occurrence WHERE genusKey = 2435098")
 
+.. note::
+    Download endpoints require GBIF credentials.
+    Set them as environment variables:
+
+    .. code-block:: bash
+
+        export GBIF_USER="your_gbif_username"
+        export GBIF_PWD="your_gbif_password"
+
+    You can also pass credentials directly via ``user=`` and ``pwd=`` arguments.
+
 Maps module
 ===========
 

--- a/docs/modules/occurrence.rst
+++ b/docs/modules/occurrence.rst
@@ -43,6 +43,17 @@ Example usage:
     occ.download_describe("simpleCsv")
     occ.download_citation("0002526-241107131044228")
 
+.. note::
+    Download endpoints require GBIF credentials.
+    Set them as environment variables:
+
+    .. code-block:: bash
+
+        export GBIF_USER="your_gbif_username"
+        export GBIF_PWD="your_gbif_password"
+
+    You can also pass credentials directly via ``user=`` and ``pwd=`` arguments.
+
 
 occurrences API
 ===============


### PR DESCRIPTION
## Summary
- add explicit note that occurrence download endpoints require GBIF credentials
- document GBIF_USER and GBIF_PWD environment variables
- note that user= and pwd= args can be passed directly

## Files
- README.rst
- docs/modules/occurrence.rst

Fixes #94
